### PR TITLE
fix: Fix logging and metrics mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@
 A simple CLI to fetch SonarQube metric(s) for component(s) and write them to a Markdown file.
 
 ## Usage
-When creating a new repository on GitHub, just choose this as a template.  
-After the new repository is created, the clean up workflow will run and
-it will replace/remove/update the repository using the new repository's name.
+
+Build the jar
+
+```sh
+./gradlew clean build
+```
+
+Use the jar
+
+```sh
+java -jar build/libs/sonarqube-report.jar [OPTIONS]
+```
+
+Run the jar with the `--help` option or without any options for more information.
 
 ## Build requirements
 - JDK 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     implementation("org.http4k:http4k-client-apache")
     implementation("org.http4k:http4k-format-jackson")
 
+    implementation("org.slf4j:slf4j-api:2.0.0")
+    implementation("org.slf4j:slf4j-simple:2.0.0")
+
     // testing
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")


### PR DESCRIPTION
### fix: Print row correctly when metrics are not provided
  If for a given metric key, there is no metric returned,
  then the row lengh does not match the header anymore.
  In this case, use "n/a" as place holder.
### fix: Fix logging issue when running the cli
### docs: Update usage in readme
